### PR TITLE
[Docs] Fix `materialize_tensor()` docstring

### DIFF
--- a/src/python/torchdistx/deferred_init.py
+++ b/src/python/torchdistx/deferred_init.py
@@ -40,7 +40,7 @@ def materialize_tensor(tensor: Tensor) -> Tensor:
     """Materializes ``tensor``.
 
     Args:
-        module:
+        tensor:
             The tensor instance to materialize.
     """
     return _C.materialize_tensor(tensor)


### PR DESCRIPTION
**What does this PR do? Please describe:**
I noticed a typo when reading the docs. This changes `module` -> `tensor` in `materialize_tensor()`'s argument part of the docstring.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible API changes.

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
