### PR TITLE
Change from pull_request_target to pull_request

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,7 +14,7 @@ on:
       - 'docker/**'
       - 'docs/**'
       - '**.md'
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - 'docker/**'
       - 'docs/**'


### PR DESCRIPTION
Start using `pull_request` instead of `pull_request_target` since it is more secure.