### PR TITLE
Add is_contiguous to FakePyInterpreter

### DIFF
--- a/src/cc/torchdistx/fake.cc
+++ b/src/cc/torchdistx/fake.cc
@@ -89,12 +89,16 @@ class FakePyInterpreter {
     failCall("dispatch");
   }
 
+  [[noreturn]] static bool is_contiguous(const PyInterpreter*, const TensorImpl*) {
+    failCall("is_contiguous");
+  }
+
   [[noreturn]] static void failCall(const char* function_name) {
     TORCH_INTERNAL_ASSERT(false,
         "`FakePyInterpreter::", function_name, "()` run unexpectedly.");
   }
 
-  FakePyInterpreter() noexcept : impl_{getName, decref, detach, dispatch} {}
+  FakePyInterpreter() noexcept : impl_{getName, decref, detach, dispatch, is_contiguous} {}
 
  public:
   FakePyInterpreter(FakePyInterpreter&) = delete;


### PR DESCRIPTION
Our nightly build catched a BC-breaking chance in c10. This PR adds a stub for the new `is_contiguous` function that was recently introduced in `c10::PyInterpreter`.
