### PR TITLE
Add device to FakePyInterpreter

### DIFF
--- a/src/cc/torchdistx/fake.cc
+++ b/src/cc/torchdistx/fake.cc
@@ -93,12 +93,16 @@ class FakePyInterpreter {
     failCall("is_contiguous");
   }
 
+  [[noreturn]] static Device device(const PyInterpreter*, const TensorImpl*) {
+    failCall("device");
+  }
+
   [[noreturn]] static void failCall(const char* function_name) {
     TORCH_INTERNAL_ASSERT(false,
         "`FakePyInterpreter::", function_name, "()` run unexpectedly.");
   }
 
-  FakePyInterpreter() noexcept : impl_{getName, decref, detach, dispatch, is_contiguous} {}
+  FakePyInterpreter() noexcept : impl_{getName, decref, detach, dispatch, is_contiguous, device} {}
 
  public:
   FakePyInterpreter(FakePyInterpreter&) = delete;


### PR DESCRIPTION
Our nightly build catched a BC-breaking chance in c10. This PR adds a stub for the new `device` function that was recently introduced in `c10::PyInterpreter`.