### PR TITLE
Preserve materialized tensors while their fakes are alive

### DIFF
--- a/tests/python/test_deferred_init.py
+++ b/tests/python/test_deferred_init.py
@@ -4,14 +4,36 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+from typing import cast
+
 import torch
+from torch import Tensor
+from torch.nn import Module, Parameter
 
-from torchdistx.deferred_init import materialize_tensor
+from torchdistx.deferred_init import deferred_init, materialize_tensor
 
 
-def test_materialize_tensor_is_noop_for_real_tensors():
+def test_materialize_tensor_is_noop_for_real_tensors() -> None:
     a = torch.ones([10])
 
     e = materialize_tensor(a)
 
     assert a is e
+
+
+def test_materialize_tensor_returns_same_tensor() -> None:
+    class FooModule(Module):
+        def __init__(self):
+            super().__init__()
+
+            self.param1 = Parameter(torch.ones([5]))
+            self.param2 = self.param1
+
+    module = deferred_init(FooModule)
+
+    a = materialize_tensor(cast(Tensor, module.param1))
+    b = materialize_tensor(cast(Tensor, module.param1))
+    c = materialize_tensor(cast(Tensor, module.param2))
+
+    assert a is b
+    assert a is c


### PR DESCRIPTION
**What does this PR do? Please describe:**
The `materialize_tensor()` API is pretty conservative with memory usage and immediately decrefs the handle to a materialized tensor once its fake tensor is materialized. However as mentioned in #10 this has been causing issues where a tensor was used as a module parameter in multiple places. Since secondary calls to `materialize_tensor()` could not retrieve the materialized tensor, we could not support such use cases.

This PR addresses this and makes sure that the fake tensor does not lose its handle to the materialized tensor until it gets deallocated. This has no negative impact on memory usage unless the user materializes a tensor, but for some reason does not use it while still keeping the fake counterpart alive. Since such a use case is a pretty weird edge case compared to the importance of supporting multiple calls to `materialize_tensor()`, it is a tradeoff we can live with.

Fixes #10 

**Does your PR introduce any breaking changes? If yes, please list them:**
No.
