### PR TITLE
Remove the undefs linker flag for Python modules

### DIFF
--- a/cmake/Helpers.cmake
+++ b/cmake/Helpers.cmake
@@ -227,12 +227,7 @@ function(torchdist_add_target target)
                 LINKER:-z,relro
         )
 
-        if(arg_PYTHON_MODULE)
-            target_link_options(${target}
-                PRIVATE
-                    LINKER:-z,undefs
-            )
-        else()
+        if(NOT arg_PYTHON_MODULE)
             target_link_options(${target}
                 PRIVATE
                     LINKER:-z,defs


### PR DESCRIPTION
**What does this PR do? Please describe:**
Removes the `undefs` linker flag which is not supported in ld gold. It does not affect the build output since it is on by default for shared libraries.

Fixes #18
