### PR TITLE
Revise meta-to-fake retrieval in Fake tensor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,5 +20,6 @@ Checks: "*,\
     -modernize-use-nodiscard,
     -modernize-use-trailing-return-type,
     -readability-else-after-return,
+    -readability-identifier-length,
     -readability-named-parameter,
     -readability-redundant-access-specifiers"

--- a/src/python/torchdistx/fake.py
+++ b/src/python/torchdistx/fake.py
@@ -25,7 +25,7 @@ def _patch_tensor_repr() -> Callable[[torch.Tensor], str]:
                 s += f", dtype={tensor.dtype}"
 
             if tensor.device.type != "cpu":
-                s += f", device={tensor.device})"
+                s += f", device={tensor.device}"
 
             if tensor.requires_grad:
                 s += ", requires_grad=True"


### PR DESCRIPTION
Relying on `PyInterpreter` for meta to fake tensor retrieval has been a fragile mechanism due to BC-breaking API changes in c10. Also the new `_meta_decompositions` work done by the core team breaks the invariant of never exposing the meta tensor of a fake tensor to Python. This new implementation, albeit slightly slower and less memory-efficient, is more robust against changes happening in the PyTorch land.