### PR TITLE
Remove --live-stream from conda run

### DIFF
--- a/.github/workflows/_test_conda.yaml
+++ b/.github/workflows/_test_conda.yaml
@@ -76,7 +76,7 @@ jobs:
         env:
           SANITIZER: ${{ matrix.sanitizer }}
         run: |
-          conda run --name test --live-stream env LD_PRELOAD=$SANITIZER_LIBRARY pytest tests
+          conda run --name test env LD_PRELOAD=$SANITIZER_LIBRARY pytest tests
 
           # Unfortunately Python leaks quite a bit of memory, so we cannot rely
           # on the output of LSan. Instead we use a rudimentary way to find out


### PR DESCRIPTION
The `--live-stream` option of `conda run` does not play well with the leak sanitizer. It sporadically hangs while writing to stderr. Since it is mostly a convenience option, removing it to avoid flaky CI.