### PR TITLE
Check meta op output

### DIFF
--- a/src/cc/torchdistx/fake.cc
+++ b/src/cc/torchdistx/fake.cc
@@ -491,7 +491,9 @@ bool FakeHandler::hasKernelForDispatchKey(DispatchKey key) const noexcept {
 
 void FakeHandler::convertMetaOutputsToFakeTensors() {
   auto fn = [this](Tensor& tensor) {
-    convertToFakeTensor(tensor);
+    if (tensor.is_meta()) {
+      convertToFakeTensor(tensor);
+    }
   };
 
   convertTensors(*stack_, handle_->schema().returns().size(), fn);


### PR DESCRIPTION
This PR makes sure that tensors returned from a meta operator are meta tensors. Technically it is possible for a meta operator to return a non-meta tensor (e.g. a scalar CPU tensor) and we do not want to cause an assertion failure in such case.
