### PR TITLE
updated requirements for future distributed tests run

### DIFF
--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -7,3 +7,4 @@ mypy==0.931
 numpy
 pytest==7.0.1
 shellcheck-py==0.8.0.4
+expecttest==0.1.3


### PR DESCRIPTION
`expecttest` is a required module by `torch/testing/_internal/common_utils.py`, which I need in future to pass CI checks.
This PR adds `expecttest` into `requirements-devel.txt`

I've tried a to install `torchdistx` from source with the updated `requirements-devel.txt` and installation is successful existing tests work.

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [X] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary) - Not necessary
- [ ] Did you write any **new necessary tests**? - Not necessary
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
