### PR TITLE
Disable TSan builds to unblock slowMo tests (3)

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -42,11 +42,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
       dev_stamp: true
@@ -67,11 +62,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
       dev_stamp: true
@@ -92,11 +82,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 
@@ -152,11 +137,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -42,11 +42,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 
@@ -60,7 +55,6 @@ jobs:
           py: ['3.7'],
           build_variant: ['cpu'],
           sanitizer: ['nosan', 'asan_ubsan']
-#          sanitizer: ['nosan', 'asan_ubsan', 'tsan']
         }
 
   test_wheel_cu102:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,11 +39,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 
@@ -63,11 +58,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 
@@ -87,11 +77,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 
@@ -147,11 +132,6 @@ jobs:
               build_variant: 'cpu',
               sanitizer: 'asan_ubsan'
             }
-#            {
-#              py: '3.7',
-#              build_variant: 'cpu',
-#              sanitizer: 'tsan'
-#            },
           ]
         }
 


### PR DESCRIPTION
Another attempt to disable TSan builds. Apparently GitHub's yaml parser fails with comment lines in JSON blocks.