### PR TITLE
Adjustments to SlowMo to work with recent changes in PyTorch

### DIFF
--- a/src/python/torchdistx/slowmo/slowmo_comm.py
+++ b/src/python/torchdistx/slowmo/slowmo_comm.py
@@ -6,10 +6,10 @@
 
 import torch
 import torch.distributed as dist
-from torch.distributed.algorithms._comm_hooks import allreduce_hook as default
+from torch.distributed.algorithms._comm_hooks import default
 
 
-class SlowMoState(default.AllReduceState):
+class SlowMoState(default.DefaultState):
     r"""
     State for the `Slow Momentum <https://arxiv.org/abs/1910.00643>`_ .
 

--- a/src/python/torchdistx/slowmo/slowmo_optimizer.py
+++ b/src/python/torchdistx/slowmo/slowmo_optimizer.py
@@ -100,6 +100,12 @@ class SlowMomentumOptimizer(torch.optim.Optimizer):
             raise ValueError(
                 "Provided base optimizer does not have parameters specified."
             )
+        for group in self._base_optim.param_groups:
+            if "lr" not in group:
+                raise ValueError(
+                    "All parameter groups should have learning rate specified."
+                )
+
         self.param_groups = self._base_optim.param_groups
 
         if slowmo_freq < 1:
@@ -176,6 +182,11 @@ class SlowMomentumOptimizer(torch.optim.Optimizer):
         self._base_optim.load_state_dict(state_dict)
         if not self.param_groups:
             raise ValueError("Base optimizer does not have parameter groups specified.")
+        for group in self._base_optim.param_groups:
+            if "lr" not in group:
+                raise ValueError(
+                    "All parameter groups should have learning rate specified."
+                )
 
     @torch.no_grad()
     def step(self):

--- a/src/python/torchdistx/slowmo/slowmo_optimizer.py
+++ b/src/python/torchdistx/slowmo/slowmo_optimizer.py
@@ -95,7 +95,7 @@ class SlowMomentumOptimizer(torch.optim.Optimizer):
             raise ValueError("Base optimizer is a required parameter.")
         self._base_optim = base_optim
 
-        # check that base optimizer's learning rate is stored in param_groups
+        # check that base optimizer's `param_groups` are present
         if not (self._base_optim.param_groups):
             raise ValueError(
                 "Provided base optimizer does not have parameters specified."
@@ -174,11 +174,8 @@ class SlowMomentumOptimizer(torch.optim.Optimizer):
         self.slowmo_lr = state_dict.pop("slowmo_lr")
         self.averager.step = state_dict.pop("step")
         self._base_optim.load_state_dict(state_dict)
-        # check that base optimizer's learning rate is stored in param_groups
-        if not (self.param_groups and self.param_groups[0]["lr"]):
-            raise ValueError(
-                "Base optimizer does not have parameters or learning rate specified."
-            )
+        if not self.param_groups:
+            raise ValueError("Base optimizer does not have parameter groups specified.")
 
     @torch.no_grad()
     def step(self):

--- a/tests/python/test_slowmo_fsdp.py
+++ b/tests/python/test_slowmo_fsdp.py
@@ -315,6 +315,14 @@ class TestCommunicationHooks(FSDPTest):
 
         self.assertEqual(slowmo_optim_dummy.averager.step, 2 * n_steps)
 
+        # Check abscent learning rate in a checkpoint
+        checkpoint = torch.load(chkpt, map_location=map_location)
+        del checkpoint["optim_state_dict"]["param_groups"][0]["lr"]
+        with self.assertRaisesRegex(
+            ValueError, "All parameter groups should have learning rate specified."
+        ):
+            slowmo_optim_dummy.load_state_dict(checkpoint["optim_state_dict"])
+
     @skip_if_lt_x_gpu(2)
     def test_slowmo_optimizer_errors(self):
         net = torch.nn.Linear(1, 3, bias=False)


### PR DESCRIPTION
**What does this PR do? Please describe:**
The very recent change in PyTorch's `torch.distributed.algorithms._comm_hooks` module substituted `AllreduceState` with 
the `DefaultState`. This PR introduces all necessary compatibility changes into SlowMo.

Plus some minor changes in comments and checks.

Testing plan:
Run existing tests, make sure there are no fails due to unresolved import, i.e. 
current import in `slowmo_comm.py` `from torch.distributed.algorithms._comm_hooks import allreduce_hook as default` 
fails, because there is no `allreduce_hook` in a master branch of PyTorch ( and in nightly version)

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
