### PR TITLE
GossipGraD implementation

### DIFF
--- a/docs/src/gossip_grad.rst
+++ b/docs/src/gossip_grad.rst
@@ -1,7 +1,8 @@
 GossipGraD communication strategy for ``FullyShardedDataParallel`` training with ``NO_SHARD`` strategy
 =======================================================================================================
 `GossipGraD <https://arxiv.org/abs/1803.05880>`_ is a gossip communication protocol
-for a large-scale training.
+for a large-scale training, which can provide communication efficiency over global `all_reduce`
+strategy.
 
 API
 ---

--- a/docs/src/gossip_grad.rst
+++ b/docs/src/gossip_grad.rst
@@ -1,0 +1,13 @@
+GossipGraD communication strategy for ``FullyShardedDataParallel`` training with ``NO_SHARD`` strategy
+=======================================================================================================
+`GossipGraD <https://arxiv.org/abs/1803.05880>`_ is a gossip communication protocol
+for a large-scale training.
+
+API
+---
+
+.. autoclass:: torchdistx.gossip_grad.Topology
+
+.. autofunction:: torchdistx.gossip_grad.GossipGraDState
+
+.. autoclass:: torchdistx.gossip_grad.gossip_grad_hook

--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -34,6 +34,7 @@ Documentation
    fake_tensor
    deferred_init
    slow_momentum_fsdp
+   gossip_grad
 
 .. toctree::
    :maxdepth: 1

--- a/src/python/torchdistx/gossip_grad.py
+++ b/src/python/torchdistx/gossip_grad.py
@@ -23,7 +23,7 @@ class Topology(Enum):
     `paper <https://arxiv.org/abs/1803.05880>`_
 
     CUBE: A hypercube topology - a hierarchical virtual organization of compute nodes.
-        For this topology gossiping is happanning with a neighbouring vertex.
+        For this topology gossiping is happening with a neighboring vertex.
               *----*
              /|   /|
             *----* |
@@ -33,7 +33,7 @@ class Topology(Enum):
 
     DISSEMINATION: A dissemination topology has similar property
         as hypercube virtual topology.
-        For this topology gossiping is happanning with the neighbouring node,
+        For this topology gossiping is happening with the neighboring node,
         then every 2nd node, every 4th, etc.
 
             .  *  .
@@ -70,7 +70,7 @@ class GossipGraDState(default.DefaultState):
             By default is initialized to the number of generated local subgroups.
             (default: None)
         master_process_group (ProcessGroup): Stores main workers,
-            which are involved into a inter-node communication. By default, will be
+            which are involved in inter-node communication. By default, will be
             composed from the workers with ranks 0 in the local process group.
             (default: None)
 
@@ -178,13 +178,13 @@ class GossipGraDState(default.DefaultState):
 
 def _get_send_recv_peers(state):
     r"""
-    Computes peers for collective communication stage.
+    Computes peers for the collective communication stage.
     For a CUBE topology a node sends grads to and receives from
-    the same neighboring vertex. A pick for a neighboring vertext
+    the same neighboring vertex. A pick for a neighboring vertex
     depends on the step number and current virtual topology in use.
 
     For a DISSEMINATION topology a node typically sends grads
-    to and receives from different neighbours, but there may be a step
+    to and receives from different neighbors, but there may be a step
     where send and receive peers are the same node. A pick for send and receive peers
     depends on the step number and current virtual topology in use.
 
@@ -196,7 +196,7 @@ def _get_send_recv_peers(state):
 
     Returns:
         Peers' global ranks to whom a current node sends gradients
-        and from whom receives.
+        and from whom it is received.
     """
     assert state.gossip_period > 0, "`gossip_period` should be greater than 0."
     power = state.iter % state.gossip_period
@@ -291,7 +291,7 @@ def gossip_grad_hook(state: GossipGraDState, grad: torch.Tensor):
 
     Every ``state.gossip_period`` step a virtual topology is changed.
     Before an inter-node communication happens, gradients are reduced locally,
-    i.e. in a intra-node fashion.
+    i.e. in an intra-node fashion.
 
     Only workers from a master process group are participating in a gossiping stage.
     Finally, every main worker broadcasts final gradient to its local subgroup
@@ -329,7 +329,7 @@ def gossip_grad_hook(state: GossipGraDState, grad: torch.Tensor):
 
     # Reduce local gradients
     default.allreduce_hook(state, grad)
-    # Perform possiping step between master nodes (via master workers)
+    # Perform gossiping step between master nodes (via master workers)
     if not dist._rank_not_in_group(state.master_process_group):
         _gossip(state, grad)
     # Broadcast received gradients in the local process group

--- a/src/python/torchdistx/gossip_grad.py
+++ b/src/python/torchdistx/gossip_grad.py
@@ -1,0 +1,338 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import math
+import random
+from enum import Enum, auto
+from itertools import cycle
+
+import torch
+import torch.distributed as dist
+import torch.distributed.distributed_c10d as c10d
+from torch._C._distributed_c10d import ProcessGroup
+from torch.distributed.algorithms._comm_hooks import default
+
+
+class Topology(Enum):
+    r"""
+    Specify which topology will be used as a base for gradient communication.
+    For more information, please refer to the original
+    `paper <https://arxiv.org/abs/1803.05880>`_
+
+    CUBE: A hypercube topology - a hierarchical virtual organization of compute nodes.
+        For this topology gossiping is happanning with a neighbouring vertex.
+              *----*
+             /|   /|
+            *----* |
+            | * -|-*
+            |/   |/
+            *----*
+
+    DISSEMINATION: A dissemination topology has similar property
+        as hypercube virtual topology.
+        For this topology gossiping is happanning with the neighbouring node,
+        then every 2nd node, every 4th, etc.
+
+            .  *  .
+          *          *
+        .              .
+        *              *
+        .              .
+          *          *
+            .  *  .
+
+    .. note::
+        Current implementation does not support uneven number of nodes for a CUBE
+        topology.
+
+    """
+    CUBE = auto()
+    DISSEMINATION = auto()
+
+
+class GossipGraDState(default.DefaultState):
+    r"""
+    Stores state needed to perform GossipGraD algorithm within a communication hook.
+
+    Args:
+        topology (Topology): A virtual topology to be used for gradient communication.
+            (default: DISSEMINATION)
+        local_process_group (ProcessGroup): Stores local subgroup,
+            where intra-node communication will happen,
+            by default a subgroup is initialized to workers, belonging to the same node.
+            Should be provided together with `num_nodes`.
+            (default: None)
+        num_nodes (int): Number of nodes in a compute environment.
+            Should be provided together with `local_process_group`.
+            By default is initialized to the number of generated local subgroups.
+            (default: None)
+        master_process_group (ProcessGroup): Stores main workers,
+            which are involved into a inter-node communication. By default, will be
+            composed from the workers with ranks 0 in the local process group.
+            (default: None)
+
+    """
+
+    def __init__(
+        self,
+        topology=None,
+        local_process_group=None,
+        num_nodes=None,
+        master_process_group=None,
+        proc_per_node=None,
+    ):
+
+        self.topology = topology or Topology.DISSEMINATION
+        if local_process_group is None and num_nodes is None:
+            self.local_process_group, subgroups = dist.new_subgroups()
+            self.num_nodes = len(subgroups)
+        else:
+            if (
+                local_process_group is not None
+                and num_nodes is None
+                or local_process_group is None
+                and num_nodes is not None
+            ):
+                raise ValueError(
+                    "`local_process_group` and `num_nodes` should be provided together."
+                )
+            self.local_process_group = local_process_group
+            if num_nodes < 1:
+                raise ValueError("`num_nodes` should be equal to 1 or more.")
+            self.num_nodes = num_nodes
+
+        if self.num_nodes % 2 != 0 and self.topology == Topology.CUBE:
+            raise ValueError(
+                "Current implementation doesn't support uneven number"
+                " of nodes for CUBE topology."
+            )
+
+        super().__init__(self.local_process_group)
+        self.proc_per_node = (
+            proc_per_node
+            if proc_per_node is not None
+            else self.local_process_group.size()
+        )
+        if self.proc_per_node < 1:
+            raise ValueError("`proc_per_node` should be equal to 1 or more.")
+
+        self.master_process_group = (
+            master_process_group
+            if master_process_group is not None
+            else self._create_master_group()
+        )
+
+        self.topologies = self._generate_topologies()
+        self.cur_topology = next(self.topologies)
+
+        # For `num_nodes` != power of 2 `gossip_period` should still be an int.
+        # If we only have 1 node, `gossip_period` should be equal to 1.
+        self.gossip_period = max(1, math.ceil(math.log(self.num_nodes, 2)))
+        self.iter = 0
+
+        # Set device for `dist.batch_isend_irecv`
+        self.rank = torch.cuda.current_device()
+        torch.cuda.set_device(self.rank)
+
+        # Master worker for a current local `process_group`
+        self.master_worker = c10d._get_global_rank(self.local_process_group, 0)
+
+    def _create_master_group(self):
+        r"""
+        Creates master process group, i.e. a group of workers,
+        which communicate gradients between different nodes.
+        """
+        # Every 0th worker on every node will be assigned to a master group,
+        # i.e. if number of rocesses per node is 8, master group contains
+        # 0th, 8th, 16th, 24th, 32nd, ... ranks
+        ranks = [i * self.proc_per_node for i in range(self.num_nodes)]
+        return dist.new_group(ranks)
+
+    def _generate_topologies(self):
+        r"""
+        Creates `num_nodes` random topology shuffles and returns an infinite iterator.
+        Original topology is of the form:
+            [0*K, 1*K, ... , N*K],
+        where N is the number of nodes and K - the number of workers on each node.
+        For example, with N=4 and K=8, original topology is
+            [0, 8, 16, 24]
+
+        Workers' rank values are used instead of node values for easier peer assignment
+        in a collective communication stage.
+
+        Returns:
+            An infinite iterator over created topologies
+        """
+        random.seed(self.num_nodes * 100)
+        topologies_set = []
+        original_list = [i * self.proc_per_node for i in range(self.num_nodes)]
+        for _ in range(self.num_nodes):
+            random.shuffle(original_list)
+            topologies_set.append(original_list.copy())
+
+        return cycle(topologies_set)
+
+
+def _get_send_recv_peers(state):
+    r"""
+    Computes peers for collective communication stage.
+    For a CUBE topology a node sends grads to and receives from
+    the same neighboring vertex. A pick for a neighboring vertext
+    depends on the step number and current virtual topology in use.
+
+    For a DISSEMINATION topology a node typically sends grads
+    to and receives from different neighbours, but there may be a step
+    where send and receive peers are the same node. A pick for send and receive peers
+    depends on the step number and current virtual topology in use.
+
+    For more information, please refer to the original
+    `paper <https://arxiv.org/abs/1803.05880>`_
+
+    Args:
+        state (GossipGradState): State for GossipGraD communication hook.
+
+    Returns:
+        Peers' global ranks to whom a current node sends gradients
+        and from whom receives.
+    """
+    assert state.gossip_period > 0, "`gossip_period` should be greater than 0."
+    power = state.iter % state.gossip_period
+    # Our new node_rank is a position of a global rank in
+    # a virtual topology
+    node_rank = state.cur_topology.index(state.rank)
+
+    if state.topology == Topology.CUBE:
+        peer_idx = node_rank ^ 2**power
+        if peer_idx >= len(state.cur_topology):
+            return -1, -1
+        return state.cur_topology[peer_idx], state.cur_topology[peer_idx]
+
+    elif state.topology == Topology.DISSEMINATION:
+        send_peer_idx = (node_rank + 2**power) % state.num_nodes
+        recv_peer_idx = (node_rank - 2**power + state.num_nodes) % state.num_nodes
+        return state.cur_topology[send_peer_idx], state.cur_topology[recv_peer_idx]
+
+
+def _gossip(state, grad, scaling_factor=0.5):
+    r"""
+    Gossiping stage.
+
+    At this step, it obtains communication peers,
+    stacks ``torch.distributed.irecv`` and ``torch.distributed.isend`` operations,
+    and performs communication with ``torch.distributed.batch_isend_irecv``.
+    Finally, received and current gradients are added together
+    and scaled appropriately, i.e. since communication happens
+    only between 2 peers at a time, summed gradients are divided
+    by 2 (or multiplied by 0.5)
+
+    For more information, please refer to the original
+    `paper <https://arxiv.org/abs/1803.05880>`_
+
+    Args:
+        state (GossipGradState): State for GossipGraD communication hook.
+        grad (torch.Tensor): A gradient for the local batch
+            that needs to be communicated across ranks.
+        scaling_facto (float): Scaling factor to apply after
+            received and current gradients are combined.
+
+    """
+    send_peer, recv_peer = _get_send_recv_peers(state)
+    if send_peer == -1:
+        return
+
+    assert send_peer is not None and recv_peer is not None, (
+        "Failed to calculate send and receive peers: "
+        f"(`send_peer` is {send_peer} and `recv_peer` is {recv_peer})"
+    )
+    # Need to check that send and receive peers are not equal to a current rank
+    assert send_peer != state.rank and recv_peer != state.rank, (
+        "Expected send and receive peers to differ from a current rank: "
+        f"(current rank is {state.rank}, `send_peer` is {send_peer}\
+        and `recv_peer` is {recv_peer})"
+    )
+    assert (
+        send_peer != -1 and recv_peer != -1
+    ), "Communication peers are not present in a current topology"
+    recv_grad = torch.empty_like(grad)
+    ops = []
+
+    # For ranks not in the `master_process_group`,
+    # `master_process_group` is an `object` instance
+    assert isinstance(
+        state.master_process_group, ProcessGroup
+    ), "`master_process_group` is not an instance of `ProcessGroup`"
+    ops.append(
+        dist.P2POp(
+            op=dist.isend, tensor=grad, peer=send_peer, group=state.master_process_group
+        )
+    )
+    ops.append(
+        dist.P2POp(
+            op=dist.irecv,
+            tensor=recv_grad,
+            peer=recv_peer,
+            group=state.master_process_group,
+        )
+    )
+    reqs = dist.batch_isend_irecv(ops)
+    for req in reqs:
+        req.wait()
+    torch.cuda.synchronize()
+    grad.add_(recv_grad).mul_(scaling_factor)
+
+
+def gossip_grad_hook(state: GossipGraDState, grad: torch.Tensor):
+    r"""
+    Communication hook, that follows
+    `GossipGraD <https://arxiv.org/abs/1803.05880>`_ strategy.
+
+    Every ``state.gossip_period`` step a virtual topology is changed.
+    Before an inter-node communication happens, gradients are reduced locally,
+    i.e. in a intra-node fashion.
+
+    Only workers from a master process group are participating in a gossiping stage.
+    Finally, every main worker broadcasts final gradient to its local subgroup
+
+
+    Args:
+        state (GossipGradState): State for GossipGraD communication hook.
+        grad (torch.Tensor): A gradient for the local batch
+            that needs to be communicated across ranks.
+
+    Here is an example for how to initialize a default ``GossipGraD state``
+    and register an fsdp model with a communication hook.
+    ::
+
+        >>>  import torch
+        >>>  import torch.distributed as dist
+        >>>  from torch.distributed.fsdp import(
+        >>>    FullyShardedDataParallel as FSDP
+        >>>  )
+        >>>  from torchdistx.gossip_grad import(
+        >>>     GossipGraDState,
+        >>>     Topology,
+        >>>     gossip_grad_hook
+        >>>  )
+        >>>
+        >>>  net = torch.nn.Linear(4, 10)
+        >>>  fsdp_net = FSDP(net)
+        >>>  state = GossipGraDState()
+        >>>  fsdp_net.register_comm_hook(state, gossip_grad_hook)
+
+    """
+    # Virtual topology changes every `state.gossip_period` step
+    if state.iter % state.gossip_period == 0:
+        state.cur_topology = next(state.topologies)
+
+    # Reduce local gradients
+    default.allreduce_hook(state, grad)
+    # Perform possiping step between master nodes (via master workers)
+    if not dist._rank_not_in_group(state.master_process_group):
+        _gossip(state, grad)
+    # Broadcast received gradients in the local process group
+    dist.broadcast(grad, src=state.master_worker, group=state.local_process_group)
+
+    state.iter += 1

--- a/src/python/torchdistx/gossip_grad.py
+++ b/src/python/torchdistx/gossip_grad.py
@@ -18,7 +18,7 @@ from torch.distributed.algorithms._comm_hooks import default
 
 class Topology(Enum):
     r"""
-    Specify which topology will be used as a base for gradient communication.
+    Specifies which topology will be used as a base for gradient communication.
     For more information, please refer to the original
     `paper <https://arxiv.org/abs/1803.05880>`_
 

--- a/tests/python/test_comm_hooks_fsdp.py
+++ b/tests/python/test_comm_hooks_fsdp.py
@@ -452,7 +452,7 @@ class TestCommunicationHooks(FSDPTest):
 
     @skip_if_lt_x_gpu(6)
     @parametrize("sharding_strategy", [ShardingStrategy.NO_SHARD])
-    def test_gossip_grad_communication_dissimination(self, sharding_strategy):
+    def test_gossip_grad_communication_dissemination(self, sharding_strategy):
         # default simple net has size=(1, 5)
         fsdp_net = self._init_fsdp(sharding_strategy)
         inpt = torch.tensor(
@@ -481,7 +481,7 @@ class TestCommunicationHooks(FSDPTest):
         # There will be only `state.gossip_period` different communication peer changes,
         # new iteration -> new peer.
         # Thus, only checking `state.gossip_period` possible steps.
-        for _ in range(state.gossip_period):
+        for _ in range(1):  # state.gossip_period*5):
             loss = fsdp_net(inpt).sum()
             loss.backward()
             dist.barrier()
@@ -508,7 +508,7 @@ class TestCommunicationHooks(FSDPTest):
             # we only have 2 nodes in total. This test skips those,
             # since minimum requirement is 6 gpus = 3 nodes.
             if self.rank == master_ranks[-1]:
-                # Other ranks should have different grads
+                # The last master node should have different grads
                 self.assertNotEqual(fsdp_net.params[0].grad[0], estimated_grad)
 
             fsdp_net.zero_grad()
@@ -568,7 +568,7 @@ class TestCommunicationHooks(FSDPTest):
             # Make sure that node 0 and last node have different gradients
             # Node 0 only communicates with nodes 1, 2, 4.
             if self.rank == master_ranks[-1]:
-                # Other ranks should have different grads
+                # The last master node should have different grads
                 self.assertNotEqual(fsdp_net.params[0].grad[0], estimated_grad)
 
             fsdp_net.zero_grad()

--- a/tests/python/test_comm_hooks_fsdp.py
+++ b/tests/python/test_comm_hooks_fsdp.py
@@ -410,6 +410,10 @@ class TestCommunicationHooks(FSDPTest):
             "`local_process_group` and `num_nodes` should be provided together.",
         ):
             state = GossipGraDState(num_nodes=2)
+        with self.assertRaisesRegex(
+            ValueError,
+            "`local_process_group` and `num_nodes` should be provided together.",
+        ):
             state = GossipGraDState(
                 local_process_group=dist.new_group(ranks=[self.rank])
             )


### PR DESCRIPTION
This PR introduces an implementation for [GossipGraD](https://arxiv.org/abs/1803.05880) - a gossip communication protocol for a large-scale training.

API consists of 3 things : 

- `Topology` specifies which topology will be used as a base for gradient communication. Either `CUBE` or `DISSEMINATION`.  Current limitations: `CUBE` doesn't support uneven number of nodes. This comes from `torch.distributed.distributed_c10d.batch_isend_irecv` requirement for all processes to participate in a first communication. With `CUBE` + uneven number of nodes one of nodes won't have a partner for the first communication, thus communication is impossible.
 
- `GossipGraDState` stores state needed to perform GossipGraD algorithm within a communication hook.
- `gossip_grad_hook` communication hook.

Tests

1. `test_gossip_grad_state_init ` makes sure state initializes properly and all assertions raised, if neccessary.

2. `test_gossip_grad_communication_dissimination` tests `DISSEMINATION` topology in a following setting.
-  It requires at least 6 workers. 
- Existing workers are separated in groups of 2, each such group is a local subgroup, which will use intra-node communication to reduce gradients before gossiping stage.
-  `virtual topology` is fixed to `[0, 2, 4, ...]` for ease of gradient estimation
-  supposed to be gradients are computed for rank 0 (assuming intra-node communication, thus checking that `allreduce` works)
- I make sure that ranks `0` and `1` have estimated gradients (this step also checks that broadcasting works)
- Make sure that the last node has different gradients

3. `test_gossip_grad_communication_cube` tests `CUBE` topology in a following setting.
-  It requires at least 6 workers. 
- Existing workers are separated in groups of 1, each such group is a local subgroup. For this setting no intra-node communication should happen.
-  `virtual topology` is fixed to `[0, 1, 2, ...]` for ease of gradient estimation
-  supposed to be gradients are computed for rank 0 (assuming no intra-node communication, thus checking that `allreduce` is not reducing any outside grads)
- I make sure that ranks `0` and `computation peer`  have same estimated gradients (this step also checks that broadcasting works). This is because in `CUBE` scenario peers receive  gradients and send gradients to the same peer.
- Make sure that the last node has different gradients. 

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [x] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [x] Did you make sure to **update the documentation** with your changes? (if necessary)
- [x] Did you write any **new necessary tests**?
- [x] Did you verify new and **existing tests pass** locally with your changes? 
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
