### PR TITLE
Remove CUDA 11.6 builds from nightlies

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -34,7 +34,7 @@ jobs:
       matrix: |
         {
           py: ['3.7', '3.8', '3.9', '3.10'],
-          build_variant: ['cpu', 'cu102', 'cu113', 'cu116'],
+          build_variant: ['cpu', 'cu102', 'cu113'],
           sanitizer: ['nosan'],
           include: [
             {
@@ -54,7 +54,7 @@ jobs:
       matrix: |
         {
           py: ['3.7', '3.8', '3.9', '3.10'],
-          build_variant: ['cpu', 'cu102', 'cu113', 'cu116'],
+          build_variant: ['cpu', 'cu102', 'cu113'],
           sanitizer: ['nosan'],
           include: [
             {
@@ -109,18 +109,6 @@ jobs:
           sanitizer: ['nosan']
         }
 
-  test_wheel_cu116:
-    name: Test (CUDA 11.6)
-    needs: test_wheel_cu113
-    uses: ./.github/workflows/_test_wheel.yaml
-    with:
-      matrix: |
-        {
-          py: ['3.7', '3.8', '3.9', '3.10'],
-          build_variant: ['cu116'],
-          sanitizer: ['nosan']
-        }
-
   test_conda_cpu:
     name: Test (CPU)
     needs: build_conda
@@ -164,28 +152,16 @@ jobs:
           sanitizer: ['nosan']
         }
 
-  test_conda_cu116:
-    name: Test (CUDA 11.6)
-    needs: test_conda_cu113
-    uses: ./.github/workflows/_test_conda.yaml
-    with:
-      matrix: |
-        {
-          py: ['3.7', '3.8', '3.9', '3.10'],
-          build_variant: ['cu116'],
-          sanitizer: ['nosan']
-        }
-
   deploy:
     name: Deploy
     if: github.event_name == 'schedule' || github.event.inputs.deploy == 'true'
-    needs: [build_doc, test_wheel_cu116, test_conda_cu116]
+    needs: [build_doc, test_wheel_cu113, test_conda_cu113]
     uses: ./.github/workflows/_deploy.yaml
     with:
       matrix: |
         {
           py: ['3.7', '3.8', '3.9', '3.10'],
-          build_variant: ['cpu', 'cu102', 'cu113', 'cu116'],
+          build_variant: ['cpu', 'cu102', 'cu113'],
         }
       s3_wheel_path: pytorch/whl/nightly
       doc_folder_override: nightly


### PR DESCRIPTION
Apparently Conda nightlies of PyTorch do not have CUDA 11.6 builds which causes torchdistx CI to fail. This PR removes CUDA 11.6 from torchdistx nightlies