### PR TITLE
Add expecttest to CI requirements

### DIFF
--- a/.github/workflows/_test_conda.yaml
+++ b/.github/workflows/_test_conda.yaml
@@ -43,6 +43,7 @@ jobs:
                        --channel pytorch-nightly\
                        --channel conda-forge\
                        numpy\
+                       expecttest==0.1.3\
                        pytest==7.0.1\
                        python==${{ matrix.py }}\
                        torchdistx


### PR DESCRIPTION
Conda tests in CI do not declare expecttest as a requirement which was recently introduced as part of the SlowMo work.