### PR TITLE
Patch for GossipGraD algorithm

### DIFF
--- a/src/python/torchdistx/gossip_grad.py
+++ b/src/python/torchdistx/gossip_grad.py
@@ -13,6 +13,7 @@ import torch
 import torch.distributed as dist
 from torch._C._distributed_c10d import ProcessGroup
 from torch.distributed.algorithms._comm_hooks import default
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 
 # Setting a constant for situations, when communication peer
 # is not present in a current environment. This may happen in CUBE topology,
@@ -72,6 +73,8 @@ class GossipGraDState(default.DefaultState):
         unexpected hang issues during the gossiping stage.
 
     Args:
+        num_modules (int): Number of FSDP modules to identify how many communication
+            calls will be performed during a backpropagation pass.
         topology (Topology): A virtual topology to be used for gradient communication.
             (default: DISSEMINATION)
         local_process_group (ProcessGroup): Stores local subgroup,
@@ -100,6 +103,7 @@ class GossipGraDState(default.DefaultState):
 
     def __init__(
         self,
+        num_modules,
         topology=None,
         local_process_group=None,
         num_nodes=None,
@@ -107,7 +111,9 @@ class GossipGraDState(default.DefaultState):
         proc_per_node=None,
         random_seed=2403,
     ):
-
+        if num_modules is None or num_modules < 1:
+            raise ValueError("`num_nodes` should bea positive integer.")
+        self.num_modules = num_modules
         self.topology = topology or Topology.DISSEMINATION
         if local_process_group is None and num_nodes is None:
             self.local_process_group, subgroups = dist.new_subgroups()
@@ -224,7 +230,7 @@ def _get_send_recv_peers(state):
         and from whom it is received.
     """
     assert state.gossip_period > 0, "`gossip_period` should be greater than 0."
-    power = state.iter % state.gossip_period
+    power = (state.iter // state.num_modules) % state.gossip_period
     # Our new node_rank is a position of a global rank in
     # a virtual topology
     node_rank = state.cur_topology.index(state.rank)
@@ -310,6 +316,20 @@ def _gossip(state, grad, scaling_factor=0.5):
     grad.add_(recv_grad).mul_(scaling_factor)
 
 
+def get_num_modules(module: torch.nn.Module):
+    r"""
+    Returns number of FSDP modules in a provided FSDP instance.
+
+    Args:
+        module (torch.nn.Module): FSDP instance
+
+    Returns:
+        int: number of FSDP modules that are nested in the input ``module``.
+
+    """
+    return len(FSDP.fsdp_modules(module))
+
+
 def gossip_grad_hook(state: GossipGraDState, grad: torch.Tensor):
     r"""
     Communication hook, that follows
@@ -339,17 +359,18 @@ def gossip_grad_hook(state: GossipGraDState, grad: torch.Tensor):
         >>>  from torchdistx.gossip_grad import(
         >>>     GossipGraDState,
         >>>     Topology,
+        >>>     get_num_modules,
         >>>     gossip_grad_hook
         >>>  )
         >>>
         >>>  net = torch.nn.Linear(4, 10)
         >>>  fsdp_net = FSDP(net)
-        >>>  state = GossipGraDState()
+        >>>  state = GossipGraDState(num_modules=get_num_modules(fsdp_net))
         >>>  fsdp_net.register_comm_hook(state, gossip_grad_hook)
 
     """
     # Virtual topology changes every `state.gossip_period` step
-    if state.iter % state.gossip_period == 0:
+    if (state.iter // state.num_modules) % state.gossip_period == 0:
         state.cur_topology = next(state.topologies)
 
     # Reduce local gradients

--- a/tests/python/test_comm_hooks_fsdp.py
+++ b/tests/python/test_comm_hooks_fsdp.py
@@ -23,7 +23,12 @@ from torch.testing._internal.common_utils import (
     run_tests,
 )
 
-from torchdistx.gossip_grad import GossipGraDState, Topology, gossip_grad_hook
+from torchdistx.gossip_grad import (
+    GossipGraDState,
+    Topology,
+    get_num_modules,
+    gossip_grad_hook,
+)
 from torchdistx.slowmo import slowmo_comm, slowmo_optimizer
 
 if not dist.is_available():
@@ -407,15 +412,20 @@ class TestCommunicationHooks(FSDPTest):
         num_devices = torch.cuda.device_count()
         with self.assertRaisesRegex(
             ValueError,
+            "`num_nodes` should bea positive integer.",
+        ):
+            state = GossipGraDState(num_modules=None, num_nodes=2)
+        with self.assertRaisesRegex(
+            ValueError,
             "`local_process_group` and `num_nodes` should be provided together.",
         ):
-            state = GossipGraDState(num_nodes=2)
+            state = GossipGraDState(num_modules=1, num_nodes=2)
         with self.assertRaisesRegex(
             ValueError,
             "`local_process_group` and `num_nodes` should be provided together.",
         ):
             state = GossipGraDState(
-                local_process_group=dist.new_group(ranks=[self.rank])
+                num_modules=1, local_process_group=dist.new_group(ranks=[self.rank])
             )
         with self.assertRaisesRegex(
             ValueError,
@@ -423,12 +433,13 @@ class TestCommunicationHooks(FSDPTest):
             " of nodes for CUBE topology.",
         ):
             state = GossipGraDState(
+                num_modules=1,
                 topology=Topology.CUBE,
                 local_process_group=dist.new_group(ranks=[self.rank]),
                 num_nodes=5,
             )
 
-        state = GossipGraDState()
+        state = GossipGraDState(num_modules=1)
         self.assertIsNotNone(state.topology)
         self.assertEqual(state.topology, Topology.DISSEMINATION)
         self.assertIsNotNone(state.num_nodes)
@@ -444,6 +455,7 @@ class TestCommunicationHooks(FSDPTest):
         self.assertEqual(state.master_worker, 0)
 
         state = GossipGraDState(
+            num_modules=1,
             topology=Topology.CUBE,
             local_process_group=dist.new_group(ranks=[self.rank]),
             num_nodes=num_devices,
@@ -466,6 +478,7 @@ class TestCommunicationHooks(FSDPTest):
         master_process_group = dist.new_group(ranks=master_ranks)
         num_nodes = torch.cuda.device_count() // 2
         state = GossipGraDState(
+            num_modules=get_num_modules(fsdp_net),
             topology=Topology.DISSEMINATION,
             local_process_group=local_process_group,
             num_nodes=num_nodes,
@@ -521,6 +534,7 @@ class TestCommunicationHooks(FSDPTest):
         inpt = torch.tensor(
             [self.rank], dtype=torch.float, device=self.rank  # type: ignore[arg-type]
         )
+
         # The following setting is created:
         # existing workers are assigned in groups of 2, each group is
         # considered as a node.
@@ -529,6 +543,7 @@ class TestCommunicationHooks(FSDPTest):
         master_ranks = list(range(num_nodes))
         master_process_group = dist.new_group(ranks=master_ranks)
         state = GossipGraDState(
+            num_modules=get_num_modules(fsdp_net),
             topology=Topology.CUBE,
             local_process_group=local_process_group,
             num_nodes=num_nodes,
@@ -541,10 +556,11 @@ class TestCommunicationHooks(FSDPTest):
         # topology for ease of computation, thus mahually hardcode 1 topology
         state.topologies = itertools.cycle([master_ranks])
         state.cur_topology = next(state.topologies)
+
         # There will be only `state.gossip_period` different communication peer changes,
         # new iteration -> new peer.
         # Thus, only checking `state.gossip_period` possible steps.
-        for _ in range(state.gossip_period):
+        for _ in range(5):  # state.gossip_period):
             loss = fsdp_net(inpt).sum()
             loss.backward()
             dist.barrier()
@@ -572,6 +588,67 @@ class TestCommunicationHooks(FSDPTest):
                 self.assertNotEqual(fsdp_net.params[0].grad[0], estimated_grad)
 
             fsdp_net.zero_grad()
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("sharding_strategy", [ShardingStrategy.NO_SHARD])
+    def test_gossip_grad_get_num_modules(self, sharding_strategy):
+        # default simple net has size=(1, 5)
+        fsdp_net = self._init_fsdp(
+            sharding_strategy,
+            net=Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+        )
+        expected_num_modules = 3
+        self.assertEqual(expected_num_modules, get_num_modules(fsdp_net))
+
+    @skip_if_lt_x_gpu(2)
+    @parametrize("sharding_strategy", [ShardingStrategy.NO_SHARD])
+    def test_gossip_grad_iteration_correctness(self, sharding_strategy):
+        # default simple net has size=(1, 5)
+        fsdp_net = self._init_fsdp(
+            sharding_strategy,
+            net=Net(has_wrapping=True, sharding_strategy=sharding_strategy),
+        )
+        inpt = torch.randn(  # type: ignore[call-overload]
+            (7, 8), dtype=torch.float, device=self.rank
+        )
+
+        # The following setting is created:
+        # existing workers are assigned in groups of 2, each group is
+        # considered as a node.
+        local_process_group, _ = dist.new_subgroups(group_size=1)
+        num_nodes = torch.cuda.device_count()
+        master_ranks = list(range(num_nodes))
+        master_process_group = dist.new_group(ranks=master_ranks)
+        state = GossipGraDState(
+            num_modules=get_num_modules(fsdp_net),
+            topology=Topology.CUBE,
+            local_process_group=local_process_group,
+            num_nodes=num_nodes,
+            master_process_group=master_process_group,
+            proc_per_node=1,
+        )
+        fsdp_net.register_comm_hook(state, gossip_grad_hook)
+
+        # For this test there will be only one default (i.e. [0, 1, 2, ...])
+        # topology for ease of computation, thus mahually hardcode 1 topology
+        state.topologies = itertools.cycle([master_ranks])
+        state.cur_topology = next(state.topologies)
+        num_epochs = 5
+
+        # There will be only `state.gossip_period` different communication peer changes,
+        # new iteration -> new peer.
+        # Thus, only checking `state.gossip_period` possible steps.
+        for _ in range(num_epochs):  # state.gossip_period):
+            loss = fsdp_net(inpt).sum()
+            loss.backward()
+            fsdp_net.zero_grad()
+
+        # At this point state.iter should be equal to 15, because
+        # we have 3 FSDP modules in fsdp_net, thus in 5 iterations
+        # `state.iter` increases 3*num_epochstimes
+        expected_iteration = 3 * num_epochs
+        self.assertEqual(expected_iteration, state.iter)
+        self.assertEqual(num_epochs, state.iter // get_num_modules(fsdp_net))
 
 
 instantiate_parametrized_tests(TestCommunicationHooks)

--- a/tests/python/test_comm_hooks_fsdp.py
+++ b/tests/python/test_comm_hooks_fsdp.py
@@ -560,7 +560,7 @@ class TestCommunicationHooks(FSDPTest):
         # There will be only `state.gossip_period` different communication peer changes,
         # new iteration -> new peer.
         # Thus, only checking `state.gossip_period` possible steps.
-        for _ in range(5):  # state.gossip_period):
+        for _ in range(state.gossip_period):
             loss = fsdp_net(inpt).sum()
             loss.backward()
             dist.barrier()
@@ -638,7 +638,7 @@ class TestCommunicationHooks(FSDPTest):
         # There will be only `state.gossip_period` different communication peer changes,
         # new iteration -> new peer.
         # Thus, only checking `state.gossip_period` possible steps.
-        for _ in range(num_epochs):  # state.gossip_period):
+        for _ in range(num_epochs):
             loss = fsdp_net(inpt).sum()
             loss.backward()
             fsdp_net.zero_grad()


### PR DESCRIPTION
**What does this PR do? Please describe:**
Currently GossipGraD algorithm increases `state.iteration` every time `comm_hook` is called and later changes topology based on this `state.iteration`. This is incorrect, because during the same backward `comm_hook` can be called multiple times. Current patch addresses this issue.

Now GossipGraD requires a `num_modules` parameter, which is used to calculate proper time when to switch topology.

Appropriate unittests are added. New experimental results show general improvement in performance.

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible API changes.

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [X] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [X] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [X] Did you make sure to **update the documentation** with your changes? (if necessary)
- [X] Did you write any **new necessary tests**?
- [X] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
