### PR TITLE
Add unittests for AnyPrecisionOptimizer

### DIFF
--- a/src/python/torchdistx/optimizers/__init__.py
+++ b/src/python/torchdistx/optimizers/__init__.py
@@ -1,1 +1,1 @@
-from . import AnyPrecisionAdamW
+from .anyprecision_optimizer import AnyPrecisionAdamW

--- a/src/python/torchdistx/optimizers/__init__.py
+++ b/src/python/torchdistx/optimizers/__init__.py
@@ -1,0 +1,1 @@
+from . import AnyPrecisionAdamW

--- a/src/python/torchdistx/optimizers/anyprecision_optimizer.py
+++ b/src/python/torchdistx/optimizers/anyprecision_optimizer.py
@@ -46,7 +46,8 @@ class AnyPrecisionAdamW(Optimizer):
             momentum_dtype = dtype for momentum  (default: BFloat32)
             variance_dtype = dtype for uncentered variance (default: BFloat16)
             compensation_buffer_dtype  = dtype for Kahan summation
-                                         buffer (default: BFloat16)
+                                         buffer (default: BFloat16). Only used if
+                                         ``use_kahan_summation=True``.
 
             # Usage
             This optimizer implements optimizer states, and Kahan summation

--- a/tests/python/test_anyprecision_optimizer.py
+++ b/tests/python/test_anyprecision_optimizer.py
@@ -9,32 +9,19 @@ import torch.nn as nn
 import torch.optim as optim
 from copy import deepcopy
 from torchdistx.optimizers.anyprecision_optimizer import AnyPrecisionAdamW
+from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     TestCase,
     run_tests,
+    parametrize,
+    instantiate_parametrized_tests,
 )
-
-# import
-
-
-# if not dist.is_available():
-#     print("Distributed not available, skipping tests", file=sys.stderr)
-#     sys.exit(0)
+import unittest
 
 
 class TestAnyPrecisionOptimizer(TestCase):
-    def test_adam_equivalence(self):
-        """
-        Tests that AnyPrecisionAdamW is equivalent to AdamW when
-        kahan summation and different dtypes for momentum, variance,
-        and compensation buffer are turned off (i.e. all float32).
-        """
-        model = nn.Sequential(
-            nn.Linear(5, 5), nn.Linear(5, 5), nn.Linear(5, 5)
-        )
 
-        model_clone = deepcopy(model)
-
+    def _test_adam_equivalence(self, model, model_clone):
         # Test non-default options
         betas = (0.8, 0.88)
         weight_decay = 0.03
@@ -56,13 +43,10 @@ class TestAnyPrecisionOptimizer(TestCase):
         for p1, p2 in zip(model_clone.parameters(), model_orig_params):
             self.assertEqual(p1, p2)
 
-
-        inp = torch.randn(5, 5)
-
         for i in range(6):
             adam_opt.zero_grad()
             anyprecision_adam.zero_grad()
-            inp = torch.randn(5, 5)
+            inp = torch.randn(5, 5, device=next(model.parameters()).device)
             model(inp).sum().backward()
             model_clone(inp).sum().backward()
             adam_opt.step()
@@ -76,7 +60,28 @@ class TestAnyPrecisionOptimizer(TestCase):
             for p1, p2 in zip(model.parameters(), model_clone.parameters()):
                 self.assertEqual(p1, p2)
 
+    @parametrize("device", ["cpu", "cuda"])
+    def test_adam_equivalence(self, device):
+        """
+        Tests that AnyPrecisionAdamW is equivalent to AdamW when
+        kahan summation and different dtypes for momentum, variance,
+        and compensation buffer are turned off (i.e. all float32).
+        """
+        if device == "cuda" and not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA not available")
 
+        model = nn.Sequential(
+            nn.Linear(5, 5), nn.Linear(5, 5), nn.Linear(5, 5)
+        )
+        if device == "cuda":
+            model.cuda()
+
+        model_clone = deepcopy(model)
+
+        self._test_adam_equivalence(model, model_clone)
+
+
+instantiate_parametrized_tests(TestAnyPrecisionOptimizer)
 
 if __name__ == "__main__":
     run_tests()

--- a/tests/python/test_anyprecision_optimizer.py
+++ b/tests/python/test_anyprecision_optimizer.py
@@ -8,7 +8,7 @@ import torch
 import torch.nn as nn
 import torch.optim as optim
 from copy import deepcopy
-from torchdistx.optimizers.anyprecision_optimizer import AnyPrecisionAdamW
+from torchdistx.optimizers import AnyPrecisionAdamW
 from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     TestCase,

--- a/tests/python/test_anyprecision_optimizer.py
+++ b/tests/python/test_anyprecision_optimizer.py
@@ -1,0 +1,82 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+from copy import deepcopy
+from torchdistx.optimizers.anyprecision_optimizer import AnyPrecisionAdamW
+from torch.testing._internal.common_utils import (
+    TestCase,
+    run_tests,
+)
+
+# import
+
+
+# if not dist.is_available():
+#     print("Distributed not available, skipping tests", file=sys.stderr)
+#     sys.exit(0)
+
+
+class TestAnyPrecisionOptimizer(TestCase):
+    def test_adam_equivalence(self):
+        """
+        Tests that AnyPrecisionAdamW is equivalent to AdamW when
+        kahan summation and different dtypes for momentum, variance,
+        and compensation buffer are turned off (i.e. all float32).
+        """
+        model = nn.Sequential(
+            nn.Linear(5, 5), nn.Linear(5, 5), nn.Linear(5, 5)
+        )
+
+        model_clone = deepcopy(model)
+
+        # Test non-default options
+        betas = (0.8, 0.88)
+        weight_decay = 0.03
+
+        adam_opt = optim.AdamW(
+            model_clone.parameters(),
+            betas=betas,
+            weight_decay=weight_decay
+        )
+        anyprecision_adam = AnyPrecisionAdamW(
+            model.parameters(),
+            variance_dtype=torch.float32,
+            betas=betas,
+            weight_decay=weight_decay
+        )
+
+        # Verify params are equal initially
+        model_orig_params = [p.clone() for p in model.parameters()]
+        for p1, p2 in zip(model_clone.parameters(), model_orig_params):
+            self.assertEqual(p1, p2)
+
+
+        inp = torch.randn(5, 5)
+
+        for i in range(6):
+            adam_opt.zero_grad()
+            anyprecision_adam.zero_grad()
+            inp = torch.randn(5, 5)
+            model(inp).sum().backward()
+            model_clone(inp).sum().backward()
+            adam_opt.step()
+            anyprecision_adam.step()
+
+            # Ensure params are modified from original
+            if i == 0:
+                for p1, p2 in zip(model.parameters(), model_orig_params):
+                    self.assertNotEqual(p1, p2)
+
+            for p1, p2 in zip(model.parameters(), model_clone.parameters()):
+                self.assertEqual(p1, p2)
+
+
+
+if __name__ == "__main__":
+    run_tests()

--- a/tests/python/test_anyprecision_optimizer.py
+++ b/tests/python/test_anyprecision_optimizer.py
@@ -4,38 +4,36 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import unittest
+from copy import deepcopy
+
 import torch
 import torch.nn as nn
 import torch.optim as optim
-from copy import deepcopy
-from torchdistx.optimizers import AnyPrecisionAdamW
-from torch.testing._internal.common_distributed import skip_if_lt_x_gpu
 from torch.testing._internal.common_utils import (
     TestCase,
-    run_tests,
-    parametrize,
     instantiate_parametrized_tests,
+    parametrize,
+    run_tests,
 )
-import unittest
+
+from torchdistx.optimizers import AnyPrecisionAdamW
 
 
 class TestAnyPrecisionOptimizer(TestCase):
-
     def _test_adam_equivalence(self, model, model_clone):
         # Test non-default options
         betas = (0.8, 0.88)
         weight_decay = 0.03
 
         adam_opt = optim.AdamW(
-            model_clone.parameters(),
-            betas=betas,
-            weight_decay=weight_decay
+            model_clone.parameters(), betas=betas, weight_decay=weight_decay
         )
         anyprecision_adam = AnyPrecisionAdamW(
             model.parameters(),
             variance_dtype=torch.float32,
             betas=betas,
-            weight_decay=weight_decay
+            weight_decay=weight_decay,
         )
 
         # Verify params are equal initially
@@ -70,9 +68,7 @@ class TestAnyPrecisionOptimizer(TestCase):
         if device == "cuda" and not torch.cuda.is_available():
             raise unittest.SkipTest("CUDA not available")
 
-        model = nn.Sequential(
-            nn.Linear(5, 5), nn.Linear(5, 5), nn.Linear(5, 5)
-        )
+        model = nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5), nn.Linear(5, 5))
         if device == "cuda":
             model.cuda()
 
@@ -85,3 +81,4 @@ instantiate_parametrized_tests(TestAnyPrecisionOptimizer)
 
 if __name__ == "__main__":
     run_tests()
+

--- a/tests/python/test_anyprecision_optimizer.py
+++ b/tests/python/test_anyprecision_optimizer.py
@@ -81,4 +81,3 @@ instantiate_parametrized_tests(TestAnyPrecisionOptimizer)
 
 if __name__ == "__main__":
     run_tests()
-


### PR DESCRIPTION
**What does this PR do? Please describe:**
Adds basic unittest for AnyPrecisionOptimizer to ensure it is equivalent to Adam under fp32 configuration. We should have unittests as the feature is being used by e.g. @stas00 and it would be good to provide correctness guarantees.

Fixes https://github.com/pytorch/torchdistx/issues/57

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible API changes.

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
