### PR TITLE
add automatic BF16 support check (network and gpu)

### DIFF
--- a/src/python/torchdistx/optimizers/anyprecision_optimizer.py
+++ b/src/python/torchdistx/optimizers/anyprecision_optimizer.py
@@ -79,8 +79,8 @@ class AnyPrecisionAdamW(Optimizer):
                 Setting to use_kahan_summation = False, and changing momentum and
                 variance dtypes to FP32, reverts this to a standard AdamW optimizer.
 
-                AnyPrecision will automatically verify proper support is present 
-                for BF16, for both GPU and network (NCCL). 
+                AnyPrecision will automatically verify proper support is present
+                for BF16, for both GPU and network (NCCL).
 
                 To train in pure BF16:
                 1 - use model.to(torch.bfloat16) to move your model
@@ -132,8 +132,8 @@ class AnyPrecisionAdamW(Optimizer):
             if not gpu_support or not network_support:
                 if not gpu_support:
                     print(
-                    f"Your GPU does not support native BFloat16.  Please adjust AnyPrecision optimizer arguments."
-                )
+                        f"Your GPU does not support native BFloat16.  Please adjust AnyPrecision optimizer arguments."
+                    )
                 if not network_support:
                     print(
                         f"Your NCCL version does not support BFloat16.  Please adjust AnyPrecision optimizer arguments."

--- a/src/python/torchdistx/optimizers/anyprecision_optimizer.py
+++ b/src/python/torchdistx/optimizers/anyprecision_optimizer.py
@@ -79,6 +79,9 @@ class AnyPrecisionAdamW(Optimizer):
                 Setting to use_kahan_summation = False, and changing momentum and
                 variance dtypes to FP32, reverts this to a standard AdamW optimizer.
 
+                AnyPrecision will automatically verify proper support is present 
+                for BF16, for both GPU and network (NCCL). 
+
                 To train in pure BF16:
                 1 - use model.to(torch.bfloat16) to move your model
                 to BF16.
@@ -125,15 +128,17 @@ class AnyPrecisionAdamW(Optimizer):
             and use_kahan_summation == True
         ):
             gpu_support, network_support = self.verify_bfloat_support()
-            if not gpu_support:
-                print(
-                    f"Your GPU does not support native BFloat16.  Please adjust AnyPrecision optimizer params"
+
+            if not gpu_support or not network_support:
+                if not gpu_support:
+                    print(
+                    f"Your GPU does not support native BFloat16.  Please adjust AnyPrecision optimizer arguments."
                 )
-            if not network_support:
-                print(
-                    f"Your NCCL version does not support BFloat16.  Please adjust AnyPrecision optimizer params"
-                )
-            raise ValueError("Missing BFloat16 support")
+                if not network_support:
+                    print(
+                        f"Your NCCL version does not support BFloat16.  Please adjust AnyPrecision optimizer arguments."
+                    )
+                raise ValueError("Missing BFloat16 support.")
 
     @torch.no_grad()
     def step(self, closure=None):


### PR DESCRIPTION
**What does this PR do? Please describe:**
Adds an automatic check for BFloat16 support to AnyPrecision optimizer (self.verify_bfloat_support()).  
This happens at optimizer init if any of the relevant states are using torch.bfloat16.  
This checks both GPU and Network (NCCL) BFloat16 support, and errs out with both error message and an exception if it fails.


Fixes #{issue number}

**Does your PR introduce any breaking changes? If yes, please list them:**
List of all backwards-incompatible API changes.

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [ ] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
