### PR TITLE
Make python sub-packages visible

### DIFF
--- a/src/python/torchdistx/__init__.py
+++ b/src/python/torchdistx/__init__.py
@@ -5,3 +5,6 @@
 # LICENSE file in the root directory of this source tree.
 
 __version__ = "0.3.0.dev0"
+
+from torchdistx import optimizers as optimizers
+from torchdistx import slowmo as slowmo


### PR DESCRIPTION
Import sub-packages in `__init__.py` so they are the attributes of the package object.

Fixes #66 

**Check list:**
- [ ] Was this **discussed and approved** via a GitHub issue? (not for typos or docs)
- [ ] Did you read the [contributor guideline](https://github.com/pytorch/torchdistx/blob/main/CONTRIBUTING.md)?
- [ x] Did you make sure that your **PR does only one thing** instead of bundling different changes together?
- [ ] Did you make sure to **update the documentation** with your changes? (if necessary)
- [ ] Did you write any **new necessary tests**?
- [ ] Did you verify new and **existing tests pass** locally with your changes?
- [ ] Did you **update the [CHANGELOG](https://github.com/pytorch/torchdistx/blob/main/CHANGELOG.md)**? (not for typos, docs, or minor internal changes)
